### PR TITLE
check-if-else in prefer-consitional-expression

### DIFF
--- a/tslint-config.json
+++ b/tslint-config.json
@@ -84,7 +84,7 @@
     "no-unused-variable": true,
     "no-var-keyword": true,
     "no-void-expression": true,
-    "prefer-conditional-expression": [true, "check-else-if"],
+    "prefer-conditional-expression": [true],
     "prefer-object-spread": true,
     "radix": true,
     "restrict-plus-operands": true,


### PR DESCRIPTION
The check-if-else option is kind of weird. I may be missing something, but this code is raising an error : 
```
let level = '';
if (process.env.NODE_ENV === 'test') {
  level = 'emerg';
} else if (process.env.NODE_ENV === 'development') {
  level = 'debug';
} else {
  level = 'info';
}
```

According to this github issue : https://github.com/palantir/tslint/issues/2899
The right way to do it (when using the `check-if-else` option) is to use ternary operators : 
```
level = (process.env.NODE_ENV === 'test')
  ? 'emerg'
  : (process.env.NODE_ENV === 'development')
    ? 'debug'
    : 'info';
```
I do not like this syntax. The rule should only raise an error when there is only one else. Example : 
```
if (process.env.NODE_ENV === 'test') {
  level = 'emerg';
} else {
  level = 'debug'
}
```