### PR TITLE
remove import-blacklist option

### DIFF
--- a/tslint-config.json
+++ b/tslint-config.json
@@ -84,7 +84,7 @@
     "no-unused-variable": true,
     "no-var-keyword": true,
     "no-void-expression": true,
-    "prefer-conditional-expression": [true, "check-else-if"],
+    "prefer-conditional-expression": [true],
     "prefer-object-spread": true,
     "radix": true,
     "restrict-plus-operands": true,

--- a/tslint-config.json
+++ b/tslint-config.json
@@ -44,7 +44,7 @@
     "ban-comma-operator": true,
     "curly": true,
     "forin": true,
-    "import-blacklist": [true, "lodash"],
+    "import-blacklist": false,
     "label-position": true,
     "no-arg": true,
     "no-bitwise": true,

--- a/tslint-config.json
+++ b/tslint-config.json
@@ -84,7 +84,7 @@
     "no-unused-variable": true,
     "no-var-keyword": true,
     "no-void-expression": true,
-    "prefer-conditional-expression": [true],
+    "prefer-conditional-expression": [true, "check-else-if"],
     "prefer-object-spread": true,
     "radix": true,
     "restrict-plus-operands": true,


### PR DESCRIPTION
Should it be a "front only" option ?

It forbids things like : 
```
import * as _ from 'lodash';
```
