### PR TITLE
issue: set no-unused-variable to false

### DIFF
--- a/tslint-config.json
+++ b/tslint-config.json
@@ -81,7 +81,7 @@
     "no-unsafe-any": true,
     "no-unsafe-finally": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
+    "no-unused-variable": false,
     "no-var-keyword": true,
     "no-void-expression": true,
     "prefer-conditional-expression": [true, "check-else-if"],


### PR DESCRIPTION
This PR might looks weird, but it solves a typescript vs tslint issue.

There are some conflicts between `no-unused-variable` rule, some other tslint rules and typescript that no one really understands.

Ex : 
https://github.com/palantir/tslint/issues/2728
https://github.com/palantir/tslint/issues/3478 (the last message of this issue should be read)

Setting this rule to false surprisingly removes this conflict.
Anyway, this rule is already checked by typescript core compiler. As it is well integrated with vs-code, there is no need to check it twice and it should be set to false. Part of the community is pushing in this direction : 
https://github.com/palantir/tslint/issues/1481