### PR TITLE
Improvements: Interface name rule, circleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+
+workflows:
+  version: 2
+  test-publish:
+    jobs:
+      - publish:
+          context: npm_publish
+          filters:
+            branches:
+              only: master
+
+
+defaults: &defaults
+  working_directory: ~/tmp
+  docker:
+    - image: node:alpine
+  environment:
+    NODE_ENV: test
+
+jobs:
+  publish:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/tmp
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/tmp/.npmrc
+      - run:
+          name: Publish package
+          command: npm publish 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yelloan/tslint",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Yelloan TSLint",
   "main": "tslint.json",
   "repository": "https://github.com/yelloan/yelloan-tslint",

--- a/tslint-config.json
+++ b/tslint-config.json
@@ -120,7 +120,7 @@
     "completed-docs": true,
     "encoding": true,
     "import-spacing": true,
-    "interface-name": [true, "always-prefix"],
+    "interface-name": false,
     "interface-over-type-literal": true,
     "jsdoc-format": [true, "check-multiline-start"],
     "match-default-export-name": true,


### PR DESCRIPTION
## Description

To enable [merging interfaces](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) from other libraries, disable the `interface-name` rule.

- Adding circleCI config to publish on npm automatically
- Update `interface-name` rule
- Bump version to 0.0.6

