### PR TITLE
Remove self and allow destructuring of array and object

### DIFF
--- a/tslint-config.json
+++ b/tslint-config.json
@@ -20,8 +20,16 @@
     "only-arrow-functions": [true, "allow-named-functions"],
     "prefer-for-of": true,
     "promise-function-async": true,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration",
-      "variable-declaration", "member-variable-declaration", "object-destructuring", "array-destructuring"],
+    "typedef": [
+      true,
+      "call-signature",
+      "arrow-call-signature",
+      "parameter",
+      "arrow-parameter",
+      "property-declaration",
+      "variable-declaration",
+      "member-variable-declaration"
+    ],
     "typedef-whitespace": [
       true,
       {

--- a/tslint-config.json
+++ b/tslint-config.json
@@ -73,9 +73,7 @@
     "no-string-literal": true,
     "no-submodule-imports": false,
     "no-switch-case-fall-through": true,
-    "no-this-assignment": [true, {
-      "allowed-names": ["^self$"]
-    }],
+    "no-this-assignment": true,
     "no-unbound-method": true,
     "no-unnecessary-class": true,
     "no-unsafe-any": true,


### PR DESCRIPTION
### Description

**Correct no this assignement**

- **Change:** Remove allowed name `self` to this assignment.
- **Behaviour as developer:**
  - Use an arrow function;
  - Disable with a comment when used for another reason (binding, generator, etc.);
- **Reference:** #2.

**Remove typedef rule for array and object destructuring**

- **Change:** Remove `"object-destructuring"` and ``in `typedef` rule;
- **Behaviour as developer:**
  - For object allow: `const {foo} = bar();`;
  - For array allow: `const [first] = bar();` or `const [first, , third] = bar();`;
  - For more details see commit `978c99b` description or references;
- **Reference:** 
  - Reason: https://github.com/yelloan/yelloan-request/pull/19;
  -  [PonyFoo article](https://ponyfoo.com/articles/es6-destructuring-in-depth#use-cases-for-destructuring).
  - [ExploringJS documentation](http://exploringjs.com/es6/ch_destructuring.html#sec_overview-destructuring)