### PR TITLE
Update: no-namespace rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yelloan/tslint",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Yelloan TSLint",
   "main": "tslint.json",
   "repository": "https://github.com/yelloan/yelloan-tslint",

--- a/tslint-config.json
+++ b/tslint-config.json
@@ -12,7 +12,7 @@
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-magic-numbers": true,
-    "no-namespace": true,
+    "no-namespace": false,
     "no-non-null-assertion": true,
     "no-parameter-reassignment": true,
     "no-reference": true,


### PR DESCRIPTION
### Description

`no-namespace` rule set to false, because of the [no-unnecessary-class](https://palantir.github.io/tslint/rules/no-unnecessary-class/) which avoids the use of a [singleton](https://basarat.gitbooks.io/typescript/docs/tips/singleton.html). Therefore, there is a conflict:

- If you create a namespace, the `no-namespace` is triggered.
- If you create a class with only static methods, the `no-unnecessary-class` is triggered and tells us to create a namespace 😅

The only way to create a singleton is to use `export default new Class()` which is not a good practice. See also https://basarat.gitbooks.io/typescript/docs/tips/defaultIsBad.html.