### PR TITLE
adjust completed-docs rule

### DIFF
--- a/tslint-config.json
+++ b/tslint-config.json
@@ -123,7 +123,7 @@
     "binary-expression-operand-order": true,
     "class-name": true,
     "comment-format": [true, "check-space"],
-    "completed-docs": true,
+    "completed-docs": [true, "classes", "enums", "interfaces", "methods", "namespaces"],
     "encoding": true,
     "import-spacing": true,
     "interface-name": false,


### PR DESCRIPTION
# description

Adjust `completed-docs` property due to a change in TSlint 5.17.0 that enforces property documentation by default.