### PR TITLE
Allow functions to not have a variable declaration typedef

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yelloan/tslint",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Yelloan TSLint",
   "main": "tslint.json",
   "repository": "https://github.com/yelloan/yelloan-tslint",

--- a/tslint-config.json
+++ b/tslint-config.json
@@ -28,6 +28,7 @@
       "arrow-parameter",
       "property-declaration",
       "variable-declaration",
+      "variable-declaration-ignore-function",
       "member-variable-declaration"
     ],
     "typedef-whitespace": [


### PR DESCRIPTION
Fix issue #11 